### PR TITLE
fix: Value could become integer

### DIFF
--- a/src/Forms/Select.php
+++ b/src/Forms/Select.php
@@ -125,6 +125,7 @@ class Select implements Stringable
     {
         $elements = [];
         foreach ($this->options as $value => $content) {
+            $value  = strval($value);
             $option = Element::option($content)->props('value ' . $value);
             if ($this->isSelected($value)) {
                 $option = $option->prop('selected selected');
@@ -150,6 +151,7 @@ class Select implements Stringable
             $type = 'checkbox';
         }
         foreach ($this->options as $value => $content) {
+            $value = strval($value);
             $id    = $this->name . '-' . $value;
             $label = Element::label($content)->props('for ' . $id);
             $input = Element::input()->omitEndTag()->props(

--- a/tests/Forms/SelectTest.php
+++ b/tests/Forms/SelectTest.php
@@ -118,4 +118,25 @@ class SelectTest extends TestCase
 
         $this->assertSame($expected, $result);
     }
+
+    /**
+     * @test
+     */
+    public function error_is_selected_value_always_string(): void // phpcs:ignore
+    {
+        $expected = <<<html
+        <div><label for="select">Select your option</label><select id="select" name="select"><option value="0">display</option></select></div>
+        html;
+
+        // Even with strict types, number-based keys become integers
+        $result = (string) Select::create(
+            'Select your option',
+            'select',
+            [
+                '0' => 'display'
+            ]
+        );
+
+        $this->assertSame($expected, $result);
+    }
 }


### PR DESCRIPTION
Scenario:

A select form control where the values are numerical:

```php
$options = [
  '0' => '0'
];

foreach ($options as $value => $content) {
  // int(0)
  var_dump($value);

  // Exception thrown because isSelected expects string
  $this->isSelected($value);
}
```

Modified the internal loops to pass value to `strval()` to convert to string type.